### PR TITLE
fix: update S3 bucket policy to allow public read access

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket_public_access_block" "website" {
 #   signing_protocol                  = "sigv4"
 # }
 
-# S3 Bucket Policy for CloudFront
+# S3 Bucket Policy for public website access
 resource "aws_s3_bucket_policy" "website" {
   bucket = aws_s3_bucket.website.id
 
@@ -42,18 +42,11 @@ resource "aws_s3_bucket_policy" "website" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AllowCloudFrontServicePrincipal"
-        Effect = "Allow"
-        Principal = {
-          Service = "cloudfront.amazonaws.com"
-        }
-        Action   = "s3:GetObject"
-        Resource = "${aws_s3_bucket.website.arn}/*"
-        Condition = {
-          StringEquals = {
-            "AWS:SourceArn" = aws_cloudfront_distribution.cdn.arn
-          }
-        }
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.website.arn}/*"
       }
     ]
   })


### PR DESCRIPTION
- Change bucket policy from CloudFront service principal to public access
- Set Principal to '*' to allow public reads for static website hosting
- Matches S3 website endpoint configuration with custom origin